### PR TITLE
start/stop timer from system tray

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -188,6 +188,12 @@ Window::Window(const QString& filename, bool backups_enabled, QWidget* parent)
 	actions_separator->setSeparator(true);
 
 	QMenu* context_menu = new QMenu(this);
+    // Add start and stop timer in the tray icon
+    context_menu->addAction(m_start_session);
+    context_menu->addAction(m_stop_session);
+
+    context_menu->addSeparator();
+
 	context_menu->addAction(m_toggle_visibility);
 	context_menu->addAction(quit_action);
 


### PR DESCRIPTION
Might be useful when you're busy with something else and don't want to open the app to start or stop the timer.